### PR TITLE
190 Fix statuses and checking for characters death

### DIFF
--- a/Assets/Scripts/Controllers/BattleScene/BattleController.cs
+++ b/Assets/Scripts/Controllers/BattleScene/BattleController.cs
@@ -209,9 +209,9 @@ namespace Controllers.BattleScene
                 var currentCharGameObject = FindCharactersGameObjectByName(character);
                 statusHandler.HandleStatuses(character, out bool skipThisTurn, currentCharGameObject);
                 if (CheckIfAnySideWon()) break;
-                if (character.Health <= 0)
+                
+                if (character.CheckIfDead())
                 {
-                    character.IsDead = true;
                     if (character.isOwnedByPlayer)
                         targetsForEnemyPool.Remove(character);
                     else
@@ -220,6 +220,7 @@ namespace Controllers.BattleScene
                     currentCharGameObject.GetComponentInChildren<Image>().color = deadCharacterTint;
                     continue;
                 }
+                
                 if (skipThisTurn)
                 {
                     Debug.Log($"{character.name} is stunned, thus the turn will be skipped. {character.StunDurationLeft} stun turns left.");

--- a/Assets/Scripts/Controllers/BattleScene/StatusHandler.cs
+++ b/Assets/Scripts/Controllers/BattleScene/StatusHandler.cs
@@ -73,6 +73,7 @@ namespace Controllers.BattleScene
                         throw new ArgumentOutOfRangeException();
                 }
                 currentCharGameObject.GetComponent<NotificationsHandler>().HandleNotification(AbilityType.Status, finalText);
+                if (character.CheckIfDead()) return;
             }
         }
     }

--- a/Assets/Scripts/ScriptableObjects/Character.cs
+++ b/Assets/Scripts/ScriptableObjects/Character.cs
@@ -7,38 +7,47 @@ namespace ScriptableObjects
     [CreateAssetMenu(fileName = "New character", menuName = "Character")]
     public class Character : ScriptableObject
     {
+        #region General info
+        [Header("General info")]
+        
         public string characterName;
         public bool isOwnedByPlayer;
         public Sprite artwork;
         [Tooltip("Character's small photo that is shown in the character inspector")]
         public Sprite artworkPortrait;
         public Ability[] abilities;
-
+        
+        #endregion
+        
         #region Character Stats
-
         [Header("Character Stats")]
+        
         public int maxHealth;
         public int maxShield;
         [Tooltip("Value that determines the order of the character in battle queue (higher is faster)")]
         public int initiative;
-
         [Tooltip("Chance percentage to break out of stun on each turn")]
         public int chanceToBreakOutOfStun;
 
         #endregion
-        
+
+        #region Current game character data
+
         public int Health { get; set; }
         public bool IsDead { get; set; }
-
-        [HideInInspector] public List<StatusType> currentlyAppliedStatuses;
-        
         public int ShieldPoints { get; set; }
-
+        
+        #region Statuses
+        
+        [HideInInspector] public List<StatusType> currentlyAppliedStatuses;
         public int BleedDurationLeft { get; set; }
-
         public int CumulatedBleedDmg { get; set; }
         public bool DodgeEverythingUntilNextTurn { get; set; }
         public int StunDurationLeft { get; set; }
+
+        #endregion
+        #endregion
+        
         
         [Header("Citybuilding")]
         public int costTitan;
@@ -52,6 +61,26 @@ namespace ScriptableObjects
             IsDead = false;
             currentlyAppliedStatuses = new List<StatusType>();
             ShieldPoints = 0;
+            BleedDurationLeft = 0;
+            CumulatedBleedDmg = 0;
+            DodgeEverythingUntilNextTurn = false;
+            StunDurationLeft = 0;
+        }
+
+        public bool CheckIfDead()
+        {
+            if (Health > 0) return false;
+            
+            IsDead = true;
+            Health = 0;
+            ShieldPoints = 0;
+            ClearAllStatuses();
+            return true;
+        }
+
+        private void ClearAllStatuses()
+        {
+            currentlyAppliedStatuses.Clear();
             BleedDurationLeft = 0;
             CumulatedBleedDmg = 0;
             DodgeEverythingUntilNextTurn = false;


### PR DESCRIPTION
Closes #190 

Fix damage not being applied when using a status
Fix the fact, that characters death wasn't checked when handling statuses
Fix shield and status not being taken off on death
Optimize checking for characters death